### PR TITLE
Fix queen edit hive query

### DIFF
--- a/app.py
+++ b/app.py
@@ -155,8 +155,10 @@ def add_queen():
 def edit_queen(id):
     queen = Queen.query.get(id)  # Fetch the Queen by ID
 
-    # Find hives where no queen is currently assigned
-    hives = Hive.query.filter(Hive.queens == None).all()  # This checks if there are no queens in the hive
+    # Find hives where no queen is currently assigned, include the current hive
+    hives = Hive.query.filter(~Hive.queens.any()).all()
+    if queen.hive and queen.hive not in hives:
+        hives.append(queen.hive)
 
     if request.method == 'POST':
         # Update queen details from form


### PR DESCRIPTION
## Summary
- include queen's current hive when editing
- use correct SQLAlchemy `~Hive.queens.any()` syntax to find hives without queens

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475f578250832ea0ac67b4059578ff