### PR TITLE
Add theme toggle

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -1,0 +1,29 @@
+// Toggle between light and dark themes using Bootstrap 5's data-bs-theme
+function setTheme(theme) {
+    document.documentElement.setAttribute('data-bs-theme', theme);
+    localStorage.setItem('theme', theme);
+    const icon = document.querySelector('#theme-toggle i');
+    if (icon) {
+        if (theme === 'dark') {
+            icon.className = 'mdi mdi-white-balance-sunny';
+        } else {
+            icon.className = 'mdi mdi-moon-waning-crescent';
+        }
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = saved || (prefersDark ? 'dark' : 'light');
+    setTheme(theme);
+
+    const toggle = document.getElementById('theme-toggle');
+    if (toggle) {
+        toggle.addEventListener('click', function () {
+            const current = document.documentElement.getAttribute('data-bs-theme');
+            const next = current === 'light' ? 'dark' : 'light';
+            setTheme(next);
+        });
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -69,6 +69,11 @@
         <a href="/queens" class="sidebar-link {% if active_page == 'queens' %}active{% endif %}">
             <i class="mdi mdi-crown"></i> Queens
         </a>
+        <div class="mt-auto p-3">
+            <button class="btn btn-outline-secondary w-100" id="theme-toggle" title="Toggle theme">
+                <i class="mdi mdi-moon-waning-crescent"></i>
+            </button>
+        </div>
     </div>
 
     <div class="content">
@@ -87,5 +92,6 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='theme.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a theme toggle button in the sidebar
- remember selected theme and switch Bootstrap theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f08e5e64832ea5e90a6e4c125497