### PR TITLE
Add basic login system

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ def login():
     return render_template('login.html')
 
 
-@app.route('/logout')
+@app.route('/logout', methods=['POST'])
 def logout():
     session.clear()
     return redirect(url_for('login'))

--- a/templates/auth_base.html
+++ b/templates/auth_base.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Hiverr{% endblock %}</title>
+    <link rel="icon" type="image/png" href="/static/hiverr.png">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.materialdesignicons.com/7.4.47/css/materialdesignicons.min.css" rel="stylesheet">
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <div class="container py-5">
+        <div class="d-flex justify-content-end mb-4">
+            <button class="btn btn-outline-secondary" id="theme-toggle" title="Toggle theme">
+                <i class="mdi mdi-moon-waning-crescent"></i>
+            </button>
+        </div>
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+              </div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='theme.js') }}"></script>
+</body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -159,6 +159,12 @@
             <button class="btn btn-outline-secondary w-100" id="theme-toggle" title="Toggle theme">
                 <i class="mdi mdi-moon-waning-crescent"></i>
             </button>
+            {% if current_user %}
+            <div class="text-white mt-3 text-center small">
+                {{ current_user.username }} |
+                <a href="{{ url_for('logout') }}" class="link-light">Log out</a>
+            </div>
+            {% endif %}
         </div>
     </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -161,9 +161,7 @@
             </button>
             {% if current_user %}
             <div class="text-white mt-3 text-center small">Hi {{ current_user.username }}!</div>
-            <form action="{{ url_for('logout') }}" method="post" onsubmit="return confirm('Are you sure you want to log out?');" class="mt-2">
-                <button type="submit" class="btn btn-danger btn-sm w-100">Log out</button>
-            </form>
+            <button type="button" class="btn btn-danger btn-sm w-100 mt-2" data-bs-toggle="modal" data-bs-target="#logoutModal">Log out</button>
             {% endif %}
         </div>
     </div>
@@ -184,6 +182,23 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <div class="modal fade" id="logoutModal" tabindex="-1" aria-labelledby="logoutModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <form class="modal-content" action="{{ url_for('logout') }}" method="post">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="logoutModalLabel">Confirm Logout</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    Are you sure you want to log out?
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Log out</button>
+                </div>
+            </form>
+        </div>
+    </div>
     <script src="{{ url_for('static', filename='theme.js') }}"></script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -160,10 +160,10 @@
                 <i class="mdi mdi-moon-waning-crescent"></i>
             </button>
             {% if current_user %}
-            <div class="text-white mt-3 text-center small">
-                {{ current_user.username }} |
-                <a href="{{ url_for('logout') }}" class="link-light">Log out</a>
-            </div>
+            <div class="text-white mt-3 text-center small">Hi {{ current_user.username }}!</div>
+            <form action="{{ url_for('logout') }}" method="post" onsubmit="return confirm('Are you sure you want to log out?');" class="mt-2">
+                <button type="submit" class="btn btn-danger btn-sm w-100">Log out</button>
+            </form>
             {% endif %}
         </div>
     </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "auth_base.html" %}
 
 {% block title %}Login - Hiverr{% endblock %}
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,5 +15,8 @@
   </div>
   <button type="submit" class="btn btn-primary">Login</button>
 </form>
-<p class="mt-3">Need an account? <a href="{{ url_for('register') }}">Register</a></p>
+<div class="mt-3">
+  Need an account?
+  <a href="{{ url_for('register') }}" class="btn btn-secondary btn-sm ms-1">Register</a>
+</div>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Login - Hiverr{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Login</h1>
+<form method="POST" class="w-50">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+<p class="mt-3">Need an account? <a href="{{ url_for('register') }}">Register</a></p>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -15,5 +15,8 @@
   </div>
   <button type="submit" class="btn btn-primary">Register</button>
 </form>
-<p class="mt-3">Already have an account? <a href="{{ url_for('login') }}">Login</a></p>
+<div class="mt-3">
+  Already have an account?
+  <a href="{{ url_for('login') }}" class="btn btn-secondary btn-sm ms-1">Login</a>
+</div>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "auth_base.html" %}
 
 {% block title %}Register - Hiverr{% endblock %}
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Register - Hiverr{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Register</h1>
+<form method="POST" class="w-50">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Register</button>
+</form>
+<p class="mt-3">Already have an account? <a href="{{ url_for('login') }}">Login</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask-based user authentication with hashed passwords
- create login, logout, and registration routes
- display logged-in user with logout link in sidebar
- redirect unauthenticated visitors to login page
- include templates for login and registration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847fcc8bfc4832eb5aa2975e1cd0be2