### PR TITLE
Add user settings page

### DIFF
--- a/app.py
+++ b/app.py
@@ -363,7 +363,8 @@ def settings():
     user = db.session.get(User, session['user_id'])
     tz_list = sorted(available_timezones())
     if not user.timezone:
-        user.timezone = datetime.now().astimezone().tzinfo.key
+        tzinfo = datetime.now().astimezone().tzinfo
+        user.timezone = getattr(tzinfo, 'key', tzinfo.tzname(None) or 'UTC')
         db.session.commit()
     if request.method == 'POST':
         section = request.form.get('section')

--- a/app.py
+++ b/app.py
@@ -362,7 +362,8 @@ def setup_2fa():
     except ModuleNotFoundError:
         pass
 
-    return render_template('setup_2fa.html', secret=secret, qr_data=qr_data)
+    template = 'setup_2fa_inner.html' if request.args.get('modal') else 'setup_2fa.html'
+    return render_template(template, secret=secret, qr_data=qr_data)
 
 
 @app.route('/disable-2fa', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -345,7 +345,7 @@ def setup_2fa():
         img.save(buf, format='PNG')
         qr_data = 'data:image/png;base64,' + base64.b64encode(buf.getvalue()).decode()
     except ModuleNotFoundError:
-        flash('Install qrcode[pil] to display a QR code', 'warning')
+        pass
 
     return render_template('setup_2fa.html', secret=secret, qr_data=qr_data)
 

--- a/app.py
+++ b/app.py
@@ -329,6 +329,7 @@ def setup_2fa():
         secret = generate_totp_secret()
         session['tmp_2fa_secret'] = secret
 
+    error = None
     if request.method == 'POST':
         token = request.form.get('token')
         if secret and verify_totp(secret, token):
@@ -339,7 +340,7 @@ def setup_2fa():
             if modal:
                 return jsonify(success=True)
             return redirect(url_for('settings'))
-        flash('Invalid authentication code', 'danger')
+        error = 'Invalid authentication code'
 
     otpauth = f"otpauth://totp/Hiverr:{user.username}?secret={secret}&issuer=Hiverr"
     qr_data = None
@@ -368,7 +369,7 @@ def setup_2fa():
         pass
 
     template = 'setup_2fa_inner.html' if modal else 'setup_2fa.html'
-    return render_template(template, secret=secret, qr_data=qr_data)
+    return render_template(template, secret=secret, qr_data=qr_data, error=error)
 
 
 @app.route('/disable-2fa', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -337,15 +337,15 @@ def setup_2fa():
         session['tmp_2fa_secret'] = secret
 
     otpauth = f"otpauth://totp/Hiverr:{user.username}?secret={secret}&issuer=Hiverr"
+    qr_data = None
     try:
         import qrcode
+        img = qrcode.make(otpauth)
+        buf = BytesIO()
+        img.save(buf, format='PNG')
+        qr_data = 'data:image/png;base64,' + base64.b64encode(buf.getvalue()).decode()
     except ModuleNotFoundError:
-        flash('qrcode package not installed', 'danger')
-        return redirect(url_for('settings'))
-    img = qrcode.make(otpauth)
-    buf = BytesIO()
-    img.save(buf, format='PNG')
-    qr_data = 'data:image/png;base64,' + base64.b64encode(buf.getvalue()).decode()
+        flash('Install qrcode[pil] to display a QR code', 'warning')
 
     return render_template('setup_2fa.html', secret=secret, qr_data=qr_data)
 

--- a/app.py
+++ b/app.py
@@ -340,10 +340,25 @@ def setup_2fa():
     qr_data = None
     try:
         import qrcode
-        img = qrcode.make(otpauth)
+        from qrcode.image.styledpil import StyledPilImage
+        from qrcode.image.styles.moduledrawers import RoundedModuleDrawer
+        from qrcode.image.styles.colormasks import RadialGradiantColorMask
+
+        qr = qrcode.QRCode(
+            error_correction=qrcode.constants.ERROR_CORRECT_Q,
+            box_size=8,
+            border=1,
+        )
+        qr.add_data(otpauth)
+        qr.make(fit=True)
+        img = qr.make_image(
+            image_factory=StyledPilImage,
+            module_drawer=RoundedModuleDrawer(),
+            color_mask=RadialGradiantColorMask(),
+        )
         buf = BytesIO()
-        img.save(buf, format='PNG')
-        qr_data = 'data:image/png;base64,' + base64.b64encode(buf.getvalue()).decode()
+        img.save(buf, format="PNG")
+        qr_data = "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
     except ModuleNotFoundError:
         pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
 Werkzeug==3.1.3
+qrcode[pil]==7.4.2

--- a/templates/base.html
+++ b/templates/base.html
@@ -156,12 +156,14 @@
         </div>
         {% endif %}
         <div class="mt-auto p-3">
-            <a href="/settings" class="sidebar-link {% if active_page == 'settings' %}active{% endif %}">
-                <i class="mdi mdi-cog"></i> Settings
-            </a>
-            <button class="btn btn-outline-secondary w-100" id="theme-toggle" title="Toggle theme">
-                <i class="mdi mdi-moon-waning-crescent"></i>
-            </button>
+            <div class="d-flex gap-2">
+                <a href="/settings" class="btn btn-outline-secondary flex-fill {% if active_page == 'settings' %}active{% endif %}" title="Settings">
+                    <i class="mdi mdi-cog"></i>
+                </a>
+                <button class="btn btn-outline-secondary flex-fill" id="theme-toggle" title="Toggle theme">
+                    <i class="mdi mdi-moon-waning-crescent"></i>
+                </button>
+            </div>
             {% if current_user %}
             <div class="d-flex align-items-center justify-content-center gap-2 mt-3">
                 {% if current_user.profile_picture %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -124,6 +124,9 @@
         <a href="/queens" class="sidebar-link {% if active_page == 'queens' %}active{% endif %}">
             <i class="mdi mdi-crown"></i> Queens
         </a>
+        <a href="/settings" class="sidebar-link {% if active_page == 'settings' %}active{% endif %}">
+            <i class="mdi mdi-cog"></i> Settings
+        </a>
         {% if sidebar_apiaries %}
         <hr class="bg-secondary mt-3 mb-1">
         <div class="text-white-50 text-center small mb-2">Your Apiaries</div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -155,10 +155,10 @@
           {% endfor %}
         </div>
         {% endif %}
-        <a href="/settings" class="sidebar-link {% if active_page == 'settings' %}active{% endif %}">
-            <i class="mdi mdi-cog"></i> Settings
-        </a>
         <div class="mt-auto p-3">
+            <a href="/settings" class="sidebar-link {% if active_page == 'settings' %}active{% endif %}">
+                <i class="mdi mdi-cog"></i> Settings
+            </a>
             <button class="btn btn-outline-secondary w-100" id="theme-toggle" title="Toggle theme">
                 <i class="mdi mdi-moon-waning-crescent"></i>
             </button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -124,9 +124,6 @@
         <a href="/queens" class="sidebar-link {% if active_page == 'queens' %}active{% endif %}">
             <i class="mdi mdi-crown"></i> Queens
         </a>
-        <a href="/settings" class="sidebar-link {% if active_page == 'settings' %}active{% endif %}">
-            <i class="mdi mdi-cog"></i> Settings
-        </a>
         {% if sidebar_apiaries %}
         <hr class="bg-secondary mt-3 mb-1">
         <div class="text-white-50 text-center small mb-2">Your Apiaries</div>
@@ -158,12 +155,20 @@
           {% endfor %}
         </div>
         {% endif %}
+        <a href="/settings" class="sidebar-link {% if active_page == 'settings' %}active{% endif %}">
+            <i class="mdi mdi-cog"></i> Settings
+        </a>
         <div class="mt-auto p-3">
             <button class="btn btn-outline-secondary w-100" id="theme-toggle" title="Toggle theme">
                 <i class="mdi mdi-moon-waning-crescent"></i>
             </button>
             {% if current_user %}
-            <div class="text-white mt-3 text-center small">Hi {{ current_user.username }}!</div>
+            <div class="d-flex align-items-center justify-content-center gap-2 mt-3">
+                {% if current_user.profile_picture %}
+                <img src="/{{ current_user.profile_picture }}" class="rounded-circle" style="width:32px;height:32px;object-fit:cover;">
+                {% endif %}
+                <span class="text-white small">Hi {{ current_user.username }}!</span>
+            </div>
             <button type="button" class="btn btn-danger btn-sm w-100 mt-2" data-bs-toggle="modal" data-bs-target="#logoutModal">Log out</button>
             {% endif %}
         </div>

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}Change Password - Hiverr{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Change Password</h1>
+<form method="POST" id="password-form" class="w-50">
+  <div class="mb-3">
+    <label for="new_password" class="form-label">New Password</label>
+    <input type="password" class="form-control" id="new_password" name="new_password" required>
+  </div>
+  <div class="mb-3">
+    <label for="confirm_password" class="form-label">Confirm Password</label>
+    <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+  </div>
+  <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmModal">Update Password</button>
+  <a href="{{ url_for('settings') }}" class="btn btn-secondary ms-2">Back</a>
+</form>
+
+<div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirmModalLabel">Confirm Password Change</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to change your password?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary" form="password-form">Yes, Change</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,20 +3,24 @@
 {% block title %}Login - Hiverr{% endblock %}
 
 {% block content %}
-<h1 class="mb-4">Login</h1>
-<form method="POST" class="w-50">
-  <div class="mb-3">
-    <label for="username" class="form-label">Username</label>
-    <input type="text" class="form-control" id="username" name="username" required>
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 380px;">
+    <h1 class="card-title mb-3 text-center">Login</h1>
+    <form method="POST">
+      <div class="mb-3">
+        <label for="username" class="form-label">Username</label>
+        <input type="text" class="form-control" id="username" name="username" required autofocus>
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Login</button>
+    </form>
+    <div class="text-center mt-3">
+      Need an account?
+      <a href="{{ url_for('register') }}" class="btn btn-secondary btn-sm ms-1">Register</a>
+    </div>
   </div>
-  <div class="mb-3">
-    <label for="password" class="form-label">Password</label>
-    <input type="password" class="form-control" id="password" name="password" required>
-  </div>
-  <button type="submit" class="btn btn-primary">Login</button>
-</form>
-<div class="mt-3">
-  Need an account?
-  <a href="{{ url_for('register') }}" class="btn btn-secondary btn-sm ms-1">Register</a>
 </div>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -3,20 +3,24 @@
 {% block title %}Register - Hiverr{% endblock %}
 
 {% block content %}
-<h1 class="mb-4">Register</h1>
-<form method="POST" class="w-50">
-  <div class="mb-3">
-    <label for="username" class="form-label">Username</label>
-    <input type="text" class="form-control" id="username" name="username" required>
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 380px;">
+    <h1 class="card-title mb-3 text-center">Register</h1>
+    <form method="POST">
+      <div class="mb-3">
+        <label for="username" class="form-label">Username</label>
+        <input type="text" class="form-control" id="username" name="username" required autofocus>
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Register</button>
+    </form>
+    <div class="text-center mt-3">
+      Already have an account?
+      <a href="{{ url_for('login') }}" class="btn btn-secondary btn-sm ms-1">Login</a>
+    </div>
   </div>
-  <div class="mb-3">
-    <label for="password" class="form-label">Password</label>
-    <input type="password" class="form-control" id="password" name="password" required>
-  </div>
-  <button type="submit" class="btn btn-primary">Register</button>
-</form>
-<div class="mt-3">
-  Already have an account?
-  <a href="{{ url_for('login') }}" class="btn btn-secondary btn-sm ms-1">Login</a>
 </div>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -107,8 +107,34 @@ document.getElementById('enable-2fa-btn')?.addEventListener('click', function(e)
     .then(r => r.text())
     .then(html => {
       document.getElementById('setup2faContent').innerHTML = html;
+      attachVerifyHandler();
     });
 });
+
+function attachVerifyHandler() {
+  const form = document.querySelector('#setup2faContent #verify-form');
+  if (!form) return;
+  form.addEventListener('submit', function(ev){
+    ev.preventDefault();
+    fetch(form.action, { method: 'POST', body: new FormData(form) })
+      .then(r => {
+        const ct = r.headers.get('Content-Type') || '';
+        if (ct.includes('application/json')) {
+          return r.json().then(data => {
+            if (data.success) {
+              bootstrap.Modal.getInstance(document.getElementById('setup2FAModal')).hide();
+              location.reload();
+            }
+          });
+        } else {
+          return r.text().then(html => {
+            document.getElementById('setup2faContent').innerHTML = html;
+            attachVerifyHandler();
+          });
+        }
+      });
+  }, { once: true });
+}
 </script>
 {% endblock %}
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -107,12 +107,20 @@ document.getElementById('enable-2fa-btn')?.addEventListener('click', function(e)
     .then(r => r.text())
     .then(html => {
       document.getElementById('setup2faContent').innerHTML = html;
-      attachVerifyHandler();
+      attachSetupHandlers();
     });
 });
 
-function attachVerifyHandler() {
+function attachSetupHandlers() {
   const form = document.querySelector('#setup2faContent #verify-form');
+  const toggle = document.querySelector('#setup2faContent #toggle-secret');
+  if (toggle) {
+    toggle.addEventListener('click', function(){
+      const pre = document.getElementById('totp-secret');
+      pre.classList.toggle('d-none');
+      toggle.classList.toggle('text-decoration-line-through');
+    });
+  }
   if (!form) return;
   form.addEventListener('submit', function(ev){
     ev.preventDefault();
@@ -129,7 +137,7 @@ function attachVerifyHandler() {
         } else {
           return r.text().then(html => {
             document.getElementById('setup2faContent').innerHTML = html;
-            attachVerifyHandler();
+            attachSetupHandlers();
           });
         }
       });

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -89,11 +89,26 @@
           </form>
         {% else %}
           <p>Two-factor authentication is disabled.</p>
-          <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary">Enable 2FA</a>
+          <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary" id="enable-2fa-btn" data-bs-toggle="modal" data-bs-target="#setup2FAModal">Enable 2FA</a>
         {% endif %}
       </div>
     </div>
   </div>
 </div>
+<div class="modal fade" id="setup2FAModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content" id="setup2faContent"></div>
+  </div>
+</div>
+<script>
+document.getElementById('enable-2fa-btn')?.addEventListener('click', function(e){
+  e.preventDefault();
+  fetch(this.getAttribute('href') + '?modal=1')
+    .then(r => r.text())
+    .then(html => {
+      document.getElementById('setup2faContent').innerHTML = html;
+    });
+});
+</script>
 {% endblock %}
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -27,12 +27,10 @@
             <label for="email" class="form-label">E-mail</label>
             <input type="email" class="form-control" id="email" name="email" value="{{ user.email or '' }}">
           </div>
-          {% if not user.profile_picture %}
           <div class="mb-3">
             <label for="profile_picture" class="form-label">Profile Picture</label>
             <input type="file" class="form-control" id="profile_picture" name="profile_picture">
           </div>
-          {% endif %}
           <button type="submit" class="btn btn-primary">Save</button>
         </form>
       </div>
@@ -86,7 +84,9 @@
         <a href="{{ url_for('change_password') }}" class="btn btn-secondary mb-3">Change Password</a>
         {% if user.two_factor_secret %}
           <p>Two-factor authentication is enabled.</p>
-          <button class="btn btn-danger" formmethod="post" formaction="{{ url_for('disable_2fa') }}">Disable 2FA</button>
+          <form method="post" action="{{ url_for('disable_2fa') }}" class="d-inline">
+            <button type="submit" class="btn btn-danger">Disable 2FA</button>
+          </form>
         {% else %}
           <p>Two-factor authentication is disabled.</p>
           <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary">Enable 2FA</a>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <h1 class="mb-4">Settings</h1>
-<form method="POST" enctype="multipart/form-data" id="settings-form">
+<form method="POST" enctype="multipart/form-data" id="settings-form" class="w-50">
   <div class="mb-3">
     <label for="full_name" class="form-label">Full Name</label>
     <input type="text" class="form-control" id="full_name" name="full_name" value="{{ user.full_name or '' }}">
@@ -26,23 +26,28 @@
   </div>
   <div class="mb-3">
     <label for="timezone" class="form-label">Timezone</label>
-    <input type="text" class="form-control" id="timezone" name="timezone" value="{{ user.timezone or '' }}">
+    <select class="form-select" id="timezone" name="timezone">
+      {% for tz in timezones %}
+      <option value="{{ tz }}" {% if user.timezone==tz %}selected{% endif %}>{{ tz }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div class="mb-3">
-    <label for="unit" class="form-label">Unit of Measurement</label>
-    <input type="text" class="form-control" id="unit" name="unit" placeholder="Enter preferred units" value="{{ user.unit or '' }}">
-  </div>
-  <hr>
-  <h5>Change Password</h5>
-  <div class="mb-3">
-    <label for="new_password" class="form-label">New Password</label>
-    <input type="password" class="form-control" id="new_password" name="new_password">
+    <label for="temperature_unit" class="form-label">Temperature Unit</label>
+    <select class="form-select" id="temperature_unit" name="temperature_unit">
+      <option value="C" {% if user.temperature_unit=='C' %}selected{% endif %}>Celsius</option>
+      <option value="F" {% if user.temperature_unit=='F' %}selected{% endif %}>Fahrenheit</option>
+    </select>
   </div>
   <div class="mb-3">
-    <label for="confirm_password" class="form-label">Confirm Password</label>
-    <input type="password" class="form-control" id="confirm_password" name="confirm_password">
+    <label for="weight_unit" class="form-label">Weight Unit</label>
+    <select class="form-select" id="weight_unit" name="weight_unit">
+      <option value="kg" {% if user.weight_unit=='kg' %}selected{% endif %}>Kilograms</option>
+      <option value="lbs" {% if user.weight_unit=='lbs' %}selected{% endif %}>Pounds</option>
+    </select>
   </div>
   <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmModal">Save Changes</button>
+  <a href="{{ url_for('change_password') }}" class="btn btn-secondary ms-2">Change Password</a>
 </form>
 
 <div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+
+{% block title %}Settings - Hiverr{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Settings</h1>
+<form method="POST" enctype="multipart/form-data" id="settings-form">
+  <div class="mb-3">
+    <label for="full_name" class="form-label">Full Name</label>
+    <input type="text" class="form-control" id="full_name" name="full_name" value="{{ user.full_name or '' }}">
+  </div>
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" value="{{ user.username }}" required>
+  </div>
+  <div class="mb-3">
+    <label for="email" class="form-label">E-mail</label>
+    <input type="email" class="form-control" id="email" name="email" value="{{ user.email or '' }}">
+  </div>
+  <div class="mb-3">
+    <label for="profile_picture" class="form-label">Profile Picture</label>
+    <input type="file" class="form-control" id="profile_picture" name="profile_picture">
+    {% if user.profile_picture %}
+    <img src="/{{ user.profile_picture }}" class="mt-2" style="height:100px;" alt="Profile picture">
+    {% endif %}
+  </div>
+  <div class="mb-3">
+    <label for="timezone" class="form-label">Timezone</label>
+    <input type="text" class="form-control" id="timezone" name="timezone" value="{{ user.timezone or '' }}">
+  </div>
+  <div class="mb-3">
+    <label for="unit" class="form-label">Unit of Measurement</label>
+    <input type="text" class="form-control" id="unit" name="unit" placeholder="Enter preferred units" value="{{ user.unit or '' }}">
+  </div>
+  <hr>
+  <h5>Change Password</h5>
+  <div class="mb-3">
+    <label for="new_password" class="form-label">New Password</label>
+    <input type="password" class="form-control" id="new_password" name="new_password">
+  </div>
+  <div class="mb-3">
+    <label for="confirm_password" class="form-label">Confirm Password</label>
+    <input type="password" class="form-control" id="confirm_password" name="confirm_password">
+  </div>
+  <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmModal">Save Changes</button>
+</form>
+
+<div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirmModalLabel">Confirm Changes</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to update your settings?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary" form="settings-form">Yes, Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -5,49 +5,72 @@
 {% block content %}
 <h1 class="mb-4">Settings</h1>
 <form method="POST" enctype="multipart/form-data" id="settings-form" class="w-50">
-  <div class="mb-3">
-    <label for="full_name" class="form-label">Full Name</label>
-    <input type="text" class="form-control" id="full_name" name="full_name" value="{{ user.full_name or '' }}">
+  <div class="card mb-4">
+    <div class="card-header">Profile</div>
+    <div class="card-body">
+      <div class="mb-3">
+        <label for="full_name" class="form-label">Full Name</label>
+        <input type="text" class="form-control" id="full_name" name="full_name" value="{{ user.full_name or '' }}">
+      </div>
+      <div class="mb-3">
+        <label for="username" class="form-label">Username</label>
+        <input type="text" class="form-control" id="username" name="username" value="{{ user.username }}" required>
+      </div>
+      <div class="mb-3">
+        <label for="email" class="form-label">E-mail</label>
+        <input type="email" class="form-control" id="email" name="email" value="{{ user.email or '' }}">
+      </div>
+      {% if not user.profile_picture %}
+      <div class="mb-3">
+        <label for="profile_picture" class="form-label">Profile Picture</label>
+        <input type="file" class="form-control" id="profile_picture" name="profile_picture">
+      </div>
+      {% endif %}
+    </div>
   </div>
-  <div class="mb-3">
-    <label for="username" class="form-label">Username</label>
-    <input type="text" class="form-control" id="username" name="username" value="{{ user.username }}" required>
+  <div class="card mb-4">
+    <div class="card-header">Units &amp; Timezone</div>
+    <div class="card-body">
+      <div class="mb-3">
+        <label for="timezone" class="form-label">Timezone</label>
+        <select class="form-select" id="timezone" name="timezone">
+          {% for tz in timezones %}
+          <option value="{{ tz }}" {% if user.timezone==tz %}selected{% endif %}>{{ tz }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="mb-3">
+        <label for="temperature_unit" class="form-label">Temperature Unit</label>
+        <select class="form-select" id="temperature_unit" name="temperature_unit">
+          <option value="C" {% if user.temperature_unit=='C' %}selected{% endif %}>Celsius</option>
+          <option value="F" {% if user.temperature_unit=='F' %}selected{% endif %}>Fahrenheit</option>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label for="weight_unit" class="form-label">Weight Unit</label>
+        <select class="form-select" id="weight_unit" name="weight_unit">
+          <option value="kg" {% if user.weight_unit=='kg' %}selected{% endif %}>Kilograms</option>
+          <option value="lbs" {% if user.weight_unit=='lbs' %}selected{% endif %}>Pounds</option>
+        </select>
+      </div>
+    </div>
   </div>
-  <div class="mb-3">
-    <label for="email" class="form-label">E-mail</label>
-    <input type="email" class="form-control" id="email" name="email" value="{{ user.email or '' }}">
-  </div>
-  <div class="mb-3">
-    <label for="profile_picture" class="form-label">Profile Picture</label>
-    <input type="file" class="form-control" id="profile_picture" name="profile_picture">
-    {% if user.profile_picture %}
-    <img src="/{{ user.profile_picture }}" class="mt-2" style="height:100px;" alt="Profile picture">
-    {% endif %}
-  </div>
-  <div class="mb-3">
-    <label for="timezone" class="form-label">Timezone</label>
-    <select class="form-select" id="timezone" name="timezone">
-      {% for tz in timezones %}
-      <option value="{{ tz }}" {% if user.timezone==tz %}selected{% endif %}>{{ tz }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div class="mb-3">
-    <label for="temperature_unit" class="form-label">Temperature Unit</label>
-    <select class="form-select" id="temperature_unit" name="temperature_unit">
-      <option value="C" {% if user.temperature_unit=='C' %}selected{% endif %}>Celsius</option>
-      <option value="F" {% if user.temperature_unit=='F' %}selected{% endif %}>Fahrenheit</option>
-    </select>
-  </div>
-  <div class="mb-3">
-    <label for="weight_unit" class="form-label">Weight Unit</label>
-    <select class="form-select" id="weight_unit" name="weight_unit">
-      <option value="kg" {% if user.weight_unit=='kg' %}selected{% endif %}>Kilograms</option>
-      <option value="lbs" {% if user.weight_unit=='lbs' %}selected{% endif %}>Pounds</option>
-    </select>
+  <div class="card mb-4">
+    <div class="card-header">Security</div>
+    <div class="card-body">
+      <a href="{{ url_for('change_password') }}" class="btn btn-secondary mb-3">Change Password</a>
+      {% if user.two_factor_secret %}
+        <p>Two-factor authentication is enabled.</p>
+        <form method="post" action="{{ url_for('disable_2fa') }}">
+          <button class="btn btn-danger" type="submit">Disable 2FA</button>
+        </form>
+      {% else %}
+        <p>Two-factor authentication is disabled.</p>
+        <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary">Enable 2FA</a>
+      {% endif %}
+    </div>
   </div>
   <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmModal">Save Changes</button>
-  <a href="{{ url_for('change_password') }}" class="btn btn-secondary ms-2">Change Password</a>
 </form>
 
 <div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -4,90 +4,96 @@
 
 {% block content %}
 <h1 class="mb-4">Settings</h1>
-<form method="POST" enctype="multipart/form-data" id="settings-form" class="w-50">
-  <div class="card mb-4">
-    <div class="card-header">Profile</div>
-    <div class="card-body">
-      <div class="mb-3">
-        <label for="full_name" class="form-label">Full Name</label>
-        <input type="text" class="form-control" id="full_name" name="full_name" value="{{ user.full_name or '' }}">
-      </div>
-      <div class="mb-3">
-        <label for="username" class="form-label">Username</label>
-        <input type="text" class="form-control" id="username" name="username" value="{{ user.username }}" required>
-      </div>
-      <div class="mb-3">
-        <label for="email" class="form-label">E-mail</label>
-        <input type="email" class="form-control" id="email" name="email" value="{{ user.email or '' }}">
-      </div>
-      {% if not user.profile_picture %}
-      <div class="mb-3">
-        <label for="profile_picture" class="form-label">Profile Picture</label>
-        <input type="file" class="form-control" id="profile_picture" name="profile_picture">
-      </div>
-      {% endif %}
-    </div>
-  </div>
-  <div class="card mb-4">
-    <div class="card-header">Units &amp; Timezone</div>
-    <div class="card-body">
-      <div class="mb-3">
-        <label for="timezone" class="form-label">Timezone</label>
-        <select class="form-select" id="timezone" name="timezone">
-          {% for tz in timezones %}
-          <option value="{{ tz }}" {% if user.timezone==tz %}selected{% endif %}>{{ tz }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="mb-3">
-        <label for="temperature_unit" class="form-label">Temperature Unit</label>
-        <select class="form-select" id="temperature_unit" name="temperature_unit">
-          <option value="C" {% if user.temperature_unit=='C' %}selected{% endif %}>Celsius</option>
-          <option value="F" {% if user.temperature_unit=='F' %}selected{% endif %}>Fahrenheit</option>
-        </select>
-      </div>
-      <div class="mb-3">
-        <label for="weight_unit" class="form-label">Weight Unit</label>
-        <select class="form-select" id="weight_unit" name="weight_unit">
-          <option value="kg" {% if user.weight_unit=='kg' %}selected{% endif %}>Kilograms</option>
-          <option value="lbs" {% if user.weight_unit=='lbs' %}selected{% endif %}>Pounds</option>
-        </select>
-      </div>
-    </div>
-  </div>
-  <div class="card mb-4">
-    <div class="card-header">Security</div>
-    <div class="card-body">
-      <a href="{{ url_for('change_password') }}" class="btn btn-secondary mb-3">Change Password</a>
-      {% if user.two_factor_secret %}
-        <p>Two-factor authentication is enabled.</p>
-        <form method="post" action="{{ url_for('disable_2fa') }}">
-          <button class="btn btn-danger" type="submit">Disable 2FA</button>
+<div class="accordion w-50" id="settingsAcc">
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="headingProfile">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseProfile" aria-expanded="false" aria-controls="collapseProfile">
+        Profile
+      </button>
+    </h2>
+    <div id="collapseProfile" class="accordion-collapse collapse" data-bs-parent="#settingsAcc">
+      <div class="accordion-body">
+        <form method="POST" enctype="multipart/form-data">
+          <input type="hidden" name="section" value="profile">
+          <div class="mb-3">
+            <label for="full_name" class="form-label">Full Name</label>
+            <input type="text" class="form-control" id="full_name" name="full_name" value="{{ user.full_name or '' }}">
+          </div>
+          <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="username" name="username" value="{{ user.username }}" required>
+          </div>
+          <div class="mb-3">
+            <label for="email" class="form-label">E-mail</label>
+            <input type="email" class="form-control" id="email" name="email" value="{{ user.email or '' }}">
+          </div>
+          {% if not user.profile_picture %}
+          <div class="mb-3">
+            <label for="profile_picture" class="form-label">Profile Picture</label>
+            <input type="file" class="form-control" id="profile_picture" name="profile_picture">
+          </div>
+          {% endif %}
+          <button type="submit" class="btn btn-primary">Save</button>
         </form>
-      {% else %}
-        <p>Two-factor authentication is disabled.</p>
-        <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary">Enable 2FA</a>
-      {% endif %}
+      </div>
     </div>
   </div>
-  <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmModal">Save Changes</button>
-</form>
-
-<div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="confirmModalLabel">Confirm Changes</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="headingUnits">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseUnits" aria-expanded="false" aria-controls="collapseUnits">
+        Units &amp; Timezone
+      </button>
+    </h2>
+    <div id="collapseUnits" class="accordion-collapse collapse" data-bs-parent="#settingsAcc">
+      <div class="accordion-body">
+        <form method="POST">
+          <input type="hidden" name="section" value="units">
+          <div class="mb-3">
+            <label for="timezone" class="form-label">Timezone</label>
+            <select class="form-select" id="timezone" name="timezone">
+              {% for tz in timezones %}
+              <option value="{{ tz }}" {% if user.timezone==tz %}selected{% endif %}>{{ tz }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="temperature_unit" class="form-label">Temperature Unit</label>
+            <select class="form-select" id="temperature_unit" name="temperature_unit">
+              <option value="C" {% if user.temperature_unit=='C' %}selected{% endif %}>Celsius</option>
+              <option value="F" {% if user.temperature_unit=='F' %}selected{% endif %}>Fahrenheit</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="weight_unit" class="form-label">Weight Unit</label>
+            <select class="form-select" id="weight_unit" name="weight_unit">
+              <option value="kg" {% if user.weight_unit=='kg' %}selected{% endif %}>Kilograms</option>
+              <option value="lbs" {% if user.weight_unit=='lbs' %}selected{% endif %}>Pounds</option>
+            </select>
+          </div>
+          <button type="submit" class="btn btn-primary">Save</button>
+        </form>
       </div>
-      <div class="modal-body">
-        Are you sure you want to update your settings?
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="submit" class="btn btn-primary" form="settings-form">Yes, Save</button>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="headingSecurity">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSecurity" aria-expanded="false" aria-controls="collapseSecurity">
+        Security
+      </button>
+    </h2>
+    <div id="collapseSecurity" class="accordion-collapse collapse" data-bs-parent="#settingsAcc">
+      <div class="accordion-body">
+        <a href="{{ url_for('change_password') }}" class="btn btn-secondary mb-3">Change Password</a>
+        {% if user.two_factor_secret %}
+          <p>Two-factor authentication is enabled.</p>
+          <button class="btn btn-danger" formmethod="post" formaction="{{ url_for('disable_2fa') }}">Disable 2FA</button>
+        {% else %}
+          <p>Two-factor authentication is disabled.</p>
+          <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary">Enable 2FA</a>
+        {% endif %}
       </div>
     </div>
   </div>
 </div>
 {% endblock %}
+

--- a/templates/setup_2fa.html
+++ b/templates/setup_2fa.html
@@ -1,22 +1,26 @@
 {% extends "base.html" %}
 {% block title %}Enable Two-Factor - Hiverr{% endblock %}
 {% block content %}
-<h1 class="mb-4">Enable Two-Factor Authentication</h1>
-<p>Scan the QR code or enter the secret in your authenticator app. Then enter the six-digit code below to confirm.</p>
-<div class="mb-3">
-  {% if qr_data %}
-  <img src="{{ qr_data }}" alt="QR Code" class="mb-3" />
-  {% else %}
-  <p class="text-warning">QR code not available. Enter the secret manually.</p>
-  {% endif %}
-  <pre>{{ secret }}</pre>
-</div>
-<form method="post" class="w-50" id="verify-form">
-  <div class="mb-3">
-    <label for="token" class="form-label">Authentication Code</label>
-    <input type="text" class="form-control" id="token" name="token" required>
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 420px;">
+    <h1 class="card-title mb-3 text-center">Enable Two-Factor Authentication</h1>
+    <p class="text-center">Scan the QR code or enter the secret below.</p>
+    {% if qr_data %}
+    <img src="{{ qr_data }}" alt="QR Code" class="d-block mx-auto mb-3 border rounded" />
+    {% else %}
+    <p class="text-warning text-center">QR code not available. Enter the secret manually.</p>
+    {% endif %}
+    <pre class="text-center">{{ secret }}</pre>
+    <form method="post" id="verify-form">
+      <div class="mb-3">
+        <label for="token" class="form-label">Authentication Code</label>
+        <input type="text" class="form-control" id="token" name="token" required>
+      </div>
+      <div class="d-flex justify-content-between">
+        <button type="submit" class="btn btn-primary">Confirm</button>
+        <a href="{{ url_for('settings') }}" class="btn btn-secondary">Cancel</a>
+      </div>
+    </form>
   </div>
-  <button type="submit" class="btn btn-primary">Confirm</button>
-  <a href="{{ url_for('settings') }}" class="btn btn-secondary ms-2">Cancel</a>
-</form>
+</div>
 {% endblock %}

--- a/templates/setup_2fa.html
+++ b/templates/setup_2fa.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Enable Two-Factor - Hiverr{% endblock %}
+{% block content %}
+<h1 class="mb-4">Enable Two-Factor Authentication</h1>
+<p>Scan the QR code or enter the secret in your authenticator app. Then enter the six-digit code below to confirm.</p>
+<div class="mb-3">
+  <img src="{{ qr_data }}" alt="QR Code" class="mb-3" />
+  <pre>{{ secret }}</pre>
+</div>
+<form method="post" class="w-50" id="verify-form">
+  <div class="mb-3">
+    <label for="token" class="form-label">Authentication Code</label>
+    <input type="text" class="form-control" id="token" name="token" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Confirm</button>
+  <a href="{{ url_for('settings') }}" class="btn btn-secondary ms-2">Cancel</a>
+</form>
+{% endblock %}

--- a/templates/setup_2fa.html
+++ b/templates/setup_2fa.html
@@ -4,7 +4,11 @@
 <h1 class="mb-4">Enable Two-Factor Authentication</h1>
 <p>Scan the QR code or enter the secret in your authenticator app. Then enter the six-digit code below to confirm.</p>
 <div class="mb-3">
+  {% if qr_data %}
   <img src="{{ qr_data }}" alt="QR Code" class="mb-3" />
+  {% else %}
+  <p class="text-warning">QR code not available. Enter the secret manually.</p>
+  {% endif %}
   <pre>{{ secret }}</pre>
 </div>
 <form method="post" class="w-50" id="verify-form">

--- a/templates/setup_2fa.html
+++ b/templates/setup_2fa.html
@@ -1,26 +1,5 @@
 {% extends "base.html" %}
 {% block title %}Enable Two-Factor - Hiverr{% endblock %}
 {% block content %}
-<div class="d-flex justify-content-center">
-  <div class="card p-4" style="max-width: 420px;">
-    <h1 class="card-title mb-3 text-center">Enable Two-Factor Authentication</h1>
-    <p class="text-center">Scan the QR code or enter the secret below.</p>
-    {% if qr_data %}
-    <img src="{{ qr_data }}" alt="QR Code" class="d-block mx-auto mb-3 border rounded" />
-    {% else %}
-    <p class="text-warning text-center">QR code not available. Enter the secret manually.</p>
-    {% endif %}
-    <pre class="text-center">{{ secret }}</pre>
-    <form method="post" id="verify-form">
-      <div class="mb-3">
-        <label for="token" class="form-label">Authentication Code</label>
-        <input type="text" class="form-control" id="token" name="token" required>
-      </div>
-      <div class="d-flex justify-content-between">
-        <button type="submit" class="btn btn-primary">Confirm</button>
-        <a href="{{ url_for('settings') }}" class="btn btn-secondary">Cancel</a>
-      </div>
-    </form>
-  </div>
-</div>
+{% include 'setup_2fa_inner.html' %}
 {% endblock %}

--- a/templates/setup_2fa_inner.html
+++ b/templates/setup_2fa_inner.html
@@ -1,14 +1,15 @@
 <div class="d-flex justify-content-center">
-  <div class="card p-4" style="max-width: 420px;">
+  <div class="card p-4 border-0" style="max-width: 420px;">
     <h1 class="card-title mb-3 text-center">Enable Two-Factor Authentication</h1>
     <p class="text-center">Scan the QR code or enter the secret below.</p>
     {% if qr_data %}
-    <img src="{{ qr_data }}" alt="QR Code" class="d-block mx-auto mb-3 border rounded" />
+    <img src="{{ qr_data }}" alt="QR Code" class="d-block mx-auto mb-3" />
     {% else %}
     <p class="text-warning text-center">QR code not available. Enter the secret manually.</p>
     {% endif %}
-    <pre class="text-center">{{ secret }}</pre>
-    <form method="post" id="verify-form">
+    <button type="button" class="btn btn-link d-block mx-auto mb-2" id="toggle-secret">Can't scan QR code? Show the TOTP key</button>
+    <pre class="text-center d-none" id="totp-secret">{{ secret }}</pre>
+    <form method="post" id="verify-form" action="{{ url_for('setup_2fa') }}?modal=1">
       <div class="mb-3">
         <label for="token" class="form-label">Authentication Code</label>
         <input type="text" class="form-control" id="token" name="token" required>
@@ -20,3 +21,10 @@
     </form>
   </div>
 </div>
+<script>
+document.getElementById('toggle-secret').addEventListener('click', function(){
+  const pre = document.getElementById('totp-secret');
+  pre.classList.toggle('d-none');
+  this.classList.toggle('text-decoration-line-through');
+});
+</script>

--- a/templates/setup_2fa_inner.html
+++ b/templates/setup_2fa_inner.html
@@ -1,13 +1,17 @@
 <div class="d-flex justify-content-center">
   <div class="card p-4 border-0" style="max-width: 420px;">
     <h1 class="card-title mb-3 text-center">Enable Two-Factor Authentication</h1>
+    {% if error %}
+    <div class="alert alert-danger" role="alert">{{ error }}</div>
+    {% else %}
     <p class="text-center">Scan the QR code or enter the secret below.</p>
+    {% endif %}
     {% if qr_data %}
     <img src="{{ qr_data }}" alt="QR Code" class="d-block mx-auto mb-3" />
     {% else %}
     <p class="text-warning text-center">QR code not available. Enter the secret manually.</p>
     {% endif %}
-    <button type="button" class="btn btn-link d-block mx-auto mb-2" id="toggle-secret">Can't scan QR code? Show the TOTP key</button>
+    <button type="button" class="btn btn-link d-block mx-auto mb-2" id="toggle-secret">Can't scan QR code? Show TOTP secret</button>
     <pre class="text-center d-none" id="totp-secret">{{ secret }}</pre>
     <form method="post" id="verify-form" action="{{ url_for('setup_2fa') }}?modal=1">
       <div class="mb-3">
@@ -22,9 +26,15 @@
   </div>
 </div>
 <script>
-document.getElementById('toggle-secret').addEventListener('click', function(){
-  const pre = document.getElementById('totp-secret');
-  pre.classList.toggle('d-none');
-  this.classList.toggle('text-decoration-line-through');
-});
+function setupTotpPage() {
+  const toggle = document.getElementById('toggle-secret');
+  if (toggle) {
+    toggle.addEventListener('click', function(){
+      const pre = document.getElementById('totp-secret');
+      pre.classList.toggle('d-none');
+      toggle.classList.toggle('text-decoration-line-through');
+    });
+  }
+}
+setupTotpPage();
 </script>

--- a/templates/setup_2fa_inner.html
+++ b/templates/setup_2fa_inner.html
@@ -1,0 +1,22 @@
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 420px;">
+    <h1 class="card-title mb-3 text-center">Enable Two-Factor Authentication</h1>
+    <p class="text-center">Scan the QR code or enter the secret below.</p>
+    {% if qr_data %}
+    <img src="{{ qr_data }}" alt="QR Code" class="d-block mx-auto mb-3 border rounded" />
+    {% else %}
+    <p class="text-warning text-center">QR code not available. Enter the secret manually.</p>
+    {% endif %}
+    <pre class="text-center">{{ secret }}</pre>
+    <form method="post" id="verify-form">
+      <div class="mb-3">
+        <label for="token" class="form-label">Authentication Code</label>
+        <input type="text" class="form-control" id="token" name="token" required>
+      </div>
+      <div class="d-flex justify-content-between">
+        <button type="submit" class="btn btn-primary">Confirm</button>
+        <a href="{{ url_for('settings') }}" class="btn btn-secondary">Cancel</a>
+      </div>
+    </form>
+  </div>
+</div>

--- a/templates/two_factor.html
+++ b/templates/two_factor.html
@@ -1,0 +1,12 @@
+{% extends "auth_base.html" %}
+{% block title %}Two-Factor Authentication - Hiverr{% endblock %}
+{% block content %}
+<h1 class="mb-4 text-center">Two-Factor Authentication</h1>
+<form method="post" class="w-50 mx-auto">
+  <div class="mb-3">
+    <label for="token" class="form-label">Authentication Code</label>
+    <input type="text" class="form-control" id="token" name="token" required autofocus>
+  </div>
+  <button type="submit" class="btn btn-primary w-100">Verify</button>
+</form>
+{% endblock %}

--- a/templates/two_factor.html
+++ b/templates/two_factor.html
@@ -1,12 +1,16 @@
 {% extends "auth_base.html" %}
 {% block title %}Two-Factor Authentication - Hiverr{% endblock %}
 {% block content %}
-<h1 class="mb-4 text-center">Two-Factor Authentication</h1>
-<form method="post" class="w-50 mx-auto">
-  <div class="mb-3">
-    <label for="token" class="form-label">Authentication Code</label>
-    <input type="text" class="form-control" id="token" name="token" required autofocus>
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 380px;">
+    <h1 class="card-title mb-4 text-center">Two-Factor Authentication</h1>
+    <form method="post">
+      <div class="mb-3">
+        <label for="token" class="form-label">Authentication Code</label>
+        <input type="text" class="form-control" id="token" name="token" required autofocus>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Verify</button>
+    </form>
   </div>
-  <button type="submit" class="btn btn-primary w-100">Verify</button>
-</form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add fields to `User` model for profile info
- create `/settings` route with update logic
- add Settings link in sidebar
- implement `settings.html` template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684828c63bd4832e9535f88909a7e47a