### PR TITLE
Implement admin setup wizard with roles

### DIFF
--- a/app.py
+++ b/app.py
@@ -467,7 +467,7 @@ def change_password():
         user.set_password(new_password)
         db.session.commit()
         flash('Password updated successfully', 'success')
-        return redirect(url_for('settings'))
+        return redirect(url_for('settings', open='security'))
     return render_template('change_password.html', active_page='settings')
 
 
@@ -534,7 +534,7 @@ def disable_2fa():
     user.two_factor_secret = None
     db.session.commit()
     flash('Two-factor authentication disabled', 'success')
-    return redirect(url_for('settings'))
+    return redirect(url_for('settings', open='security'))
 
 
 @app.route('/toggle-registration', methods=['POST'])
@@ -551,7 +551,7 @@ def toggle_registration():
     db.session.commit()
     msg = 'User registration enabled' if enable else 'User registration disabled'
     flash(msg, 'success')
-    return redirect(url_for('settings'))
+    return redirect(url_for('settings', open='security'))
 
 @app.route('/settings', methods=['GET', 'POST'])
 def settings():
@@ -583,7 +583,7 @@ def settings():
 
         db.session.commit()
         flash('Settings updated successfully', 'success')
-        return redirect(url_for('settings'))
+        return redirect(url_for('settings', open=section))
 
     return render_template('settings.html', user=user, timezones=tz_list, active_page='settings')
 

--- a/app.py
+++ b/app.py
@@ -610,6 +610,30 @@ def create_user():
     flash('User created successfully', 'success')
     return redirect(url_for('settings', open='users'))
 
+
+@app.route('/delete-user/<int:id>', methods=['POST'])
+def delete_user(id):
+    admin = db.session.get(User, session['user_id'])
+    if admin.role != 'admin':
+        abort(403)
+    if admin.id == id:
+        flash("You cannot delete your own account", 'danger')
+        return redirect(url_for('settings', open='users'))
+    user = db.session.get(User, id)
+    if not user:
+        flash('User not found', 'danger')
+        return redirect(url_for('settings', open='users'))
+    for queen in list(user.queens):
+        db.session.delete(queen)
+    for hive in list(user.hives):
+        db.session.delete(hive)
+    for apiary in list(user.apiaries):
+        db.session.delete(apiary)
+    db.session.delete(user)
+    db.session.commit()
+    flash('User deleted', 'success')
+    return redirect(url_for('settings', open='users'))
+
 @app.route('/settings', methods=['GET', 'POST'])
 def settings():
     user = db.session.get(User, session['user_id'])

--- a/app.py
+++ b/app.py
@@ -537,18 +537,20 @@ def disable_2fa():
     return redirect(url_for('settings'))
 
 
-@app.route('/enable-registration', methods=['POST'])
-def enable_registration():
+@app.route('/toggle-registration', methods=['POST'])
+def toggle_registration():
     user = db.session.get(User, session['user_id'])
     if user.role != 'admin':
         abort(403)
+    enable = 'enable' in request.form
     cfg = db.session.get(Config, 'registration_enabled')
-    if cfg:
-        cfg.value = '1'
-    else:
-        db.session.add(Config(key='registration_enabled', value='1'))
+    if not cfg:
+        cfg = Config(key='registration_enabled', value='0')
+        db.session.add(cfg)
+    cfg.value = '1' if enable else '0'
     db.session.commit()
-    flash('User registration enabled', 'success')
+    msg = 'User registration enabled' if enable else 'User registration disabled'
+    flash(msg, 'success')
     return redirect(url_for('settings'))
 
 @app.route('/settings', methods=['GET', 'POST'])

--- a/app.py
+++ b/app.py
@@ -489,6 +489,9 @@ def change_password():
         if new_password != confirm_password:
             flash('Passwords do not match', 'danger')
             return redirect(url_for('change_password'))
+        if user.check_password(new_password):
+            flash('New password must be different from the old password', 'danger')
+            return redirect(url_for('change_password'))
         user.set_password(new_password)
         user.must_change_password = False
         db.session.commit()

--- a/app.py
+++ b/app.py
@@ -596,6 +596,7 @@ def create_user():
     email = request.form.get('email') or None
     username = request.form.get('username')
     password = request.form.get('password')
+    role = request.form.get('role', 'user')
     force_change = request.form.get('force_change') == '1'
     if User.query.filter_by(username=username).first():
         flash('Username already exists', 'danger')
@@ -603,7 +604,9 @@ def create_user():
     if not password_valid(password):
         flash('Password must be at least 8 characters long and include upper, lower and special characters.', 'danger')
         return redirect(url_for('settings', open='users'))
-    new_user = User(username=username, full_name=full_name, email=email, must_change_password=force_change)
+    if role not in ('admin', 'user'):
+        role = 'user'
+    new_user = User(username=username, full_name=full_name, email=email, role=role, must_change_password=force_change)
     new_user.set_password(password)
     db.session.add(new_user)
     db.session.commit()

--- a/static/theme.js
+++ b/static/theme.js
@@ -26,4 +26,12 @@ document.addEventListener('DOMContentLoaded', function () {
             setTheme(next);
         });
     }
+
+    window.showAlert = function(message, category='success') {
+        const wrapper = document.createElement('div');
+        wrapper.className = `alert alert-${category} alert-dismissible fade show`;
+        wrapper.role = 'alert';
+        wrapper.innerHTML = `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
+        document.querySelector('.content')?.prepend(wrapper);
+    }
 });

--- a/static/theme.js
+++ b/static/theme.js
@@ -15,7 +15,7 @@ function setTheme(theme) {
 // Display a Bootstrap alert with a progress bar that fades automatically
 window.showAlert = function (message, category = 'success') {
     const wrapper = document.createElement('div');
-    wrapper.className = 'alert alert-dismissible shadow position-relative';
+    wrapper.className = 'alert alert-dismissible shadow position-relative rounded custom-alert';
     wrapper.role = 'alert';
     wrapper.innerHTML = `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
 

--- a/static/theme.js
+++ b/static/theme.js
@@ -15,7 +15,7 @@ function setTheme(theme) {
 // Display a Bootstrap alert with a progress bar that fades automatically
 window.showAlert = function (message, category = 'success') {
     const wrapper = document.createElement('div');
-    wrapper.className = 'alert alert-dismissible shadow position-relative rounded custom-alert';
+    wrapper.className = 'alert alert-dismissible shadow-lg position-relative rounded bg-body-secondary text-body border-0';
     wrapper.role = 'alert';
     wrapper.innerHTML = `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
 

--- a/static/theme.js
+++ b/static/theme.js
@@ -15,7 +15,7 @@ function setTheme(theme) {
 // Display a Bootstrap alert with a progress bar that fades automatically
 window.showAlert = function (message, category = 'success') {
     const wrapper = document.createElement('div');
-    wrapper.className = `alert alert-${category} alert-dismissible shadow position-relative`;
+    wrapper.className = 'alert alert-dismissible shadow position-relative';
     wrapper.role = 'alert';
     wrapper.innerHTML = `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
 
@@ -49,7 +49,11 @@ window.showAlert = function (message, category = 'success') {
         }, 50);
     }
 
-    wrapper.addEventListener('mouseenter', () => clearInterval(timer));
+    wrapper.addEventListener('mouseenter', () => {
+        clearInterval(timer);
+        remaining = duration;
+        progress.style.width = '100%';
+    });
     wrapper.addEventListener('mouseleave', () => startTimer());
 
     startTimer();

--- a/static/theme.js
+++ b/static/theme.js
@@ -12,12 +12,18 @@ function setTheme(theme) {
     }
 }
 
-// Display a Bootstrap alert that fades automatically after three seconds
-window.showAlert = function(message, category='success') {
+// Display a Bootstrap alert with a progress bar that fades automatically
+window.showAlert = function (message, category = 'success') {
     const wrapper = document.createElement('div');
-    wrapper.className = `alert alert-${category} alert-dismissible fade show`;
+    wrapper.className = `alert alert-${category} alert-dismissible shadow position-relative`;
     wrapper.role = 'alert';
     wrapper.innerHTML = `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
+
+    const progress = document.createElement('div');
+    progress.className = `alert-progress bg-${category}`;
+    progress.style.width = '100%';
+    wrapper.appendChild(progress);
+
     let container = document.getElementById('alerts');
     if (!container) {
         container = document.createElement('div');
@@ -27,10 +33,26 @@ window.showAlert = function(message, category='success') {
         document.body.appendChild(container);
     }
     container.appendChild(wrapper);
-    setTimeout(() => {
-        const alert = bootstrap.Alert.getOrCreateInstance(wrapper);
-        alert.close();
-    }, 3000);
+
+    const duration = 3000;
+    let remaining = duration;
+    let timer;
+    function startTimer() {
+        timer = setInterval(() => {
+            remaining -= 50;
+            const pct = Math.max(0, remaining / duration * 100);
+            progress.style.width = pct + '%';
+            if (remaining <= 0) {
+                clearInterval(timer);
+                bootstrap.Alert.getOrCreateInstance(wrapper).close();
+            }
+        }, 50);
+    }
+
+    wrapper.addEventListener('mouseenter', () => clearInterval(timer));
+    wrapper.addEventListener('mouseleave', () => startTimer());
+
+    startTimer();
 };
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/static/theme.js
+++ b/static/theme.js
@@ -12,6 +12,27 @@ function setTheme(theme) {
     }
 }
 
+// Display a Bootstrap alert that fades automatically after three seconds
+window.showAlert = function(message, category='success') {
+    const wrapper = document.createElement('div');
+    wrapper.className = `alert alert-${category} alert-dismissible fade show`;
+    wrapper.role = 'alert';
+    wrapper.innerHTML = `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
+    let container = document.getElementById('alerts');
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'alerts';
+        container.className = 'position-fixed bottom-0 end-0 p-3';
+        container.style.zIndex = '1100';
+        document.body.appendChild(container);
+    }
+    container.appendChild(wrapper);
+    setTimeout(() => {
+        const alert = bootstrap.Alert.getOrCreateInstance(wrapper);
+        alert.close();
+    }, 3000);
+};
+
 document.addEventListener('DOMContentLoaded', function () {
     const saved = localStorage.getItem('theme');
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -27,23 +48,5 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    window.showAlert = function(message, category='success') {
-        const wrapper = document.createElement('div');
-        wrapper.className = `alert alert-${category} alert-dismissible fade show`;
-        wrapper.role = 'alert';
-        wrapper.innerHTML = `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
-        let container = document.getElementById('alerts');
-        if (!container) {
-            container = document.createElement('div');
-            container.id = 'alerts';
-            container.className = 'position-fixed bottom-0 end-0 p-3';
-            container.style.zIndex = '1100';
-            document.body.appendChild(container);
-        }
-        container.appendChild(wrapper);
-        setTimeout(() => {
-            const alert = bootstrap.Alert.getOrCreateInstance(wrapper);
-            alert.close();
-        }, 3000);
-    }
+    // DOM is ready; nothing to do here for alerts since showAlert is global
 });

--- a/static/theme.js
+++ b/static/theme.js
@@ -32,6 +32,18 @@ document.addEventListener('DOMContentLoaded', function () {
         wrapper.className = `alert alert-${category} alert-dismissible fade show`;
         wrapper.role = 'alert';
         wrapper.innerHTML = `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
-        document.querySelector('.content')?.prepend(wrapper);
+        let container = document.getElementById('alerts');
+        if (!container) {
+            container = document.createElement('div');
+            container.id = 'alerts';
+            container.className = 'position-fixed bottom-0 end-0 p-3';
+            container.style.zIndex = '1100';
+            document.body.appendChild(container);
+        }
+        container.appendChild(wrapper);
+        setTimeout(() => {
+            const alert = bootstrap.Alert.getOrCreateInstance(wrapper);
+            alert.close();
+        }, 3000);
     }
 });

--- a/templates/add_apiary.html
+++ b/templates/add_apiary.html
@@ -4,19 +4,6 @@
 
 {% block content %}
 <h1 class="mb-4">Add New Apiary</h1>
-
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    {% for category, message in messages %}
-      <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-        {{ message }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    {% endfor %}
-  {% endif %}
-{% endwith %}
-
-
 <form method="POST" class="row g-3">
   <div class="col-md-6">
     <label for="name" class="form-label">Name</label>

--- a/templates/add_hive.html
+++ b/templates/add_hive.html
@@ -5,18 +5,6 @@
 {% block content %}
 <h1 class="mb-4">Add New Hive</h1>
 
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    {% for category, message in messages %}
-      <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-        {{ message }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    {% endfor %}
-  {% endif %}
-{% endwith %}
-
-
 {% if apiaries %}
 <form method="POST" class="row g-3">
   <div class="col-md-6">

--- a/templates/add_queen.html
+++ b/templates/add_queen.html
@@ -5,18 +5,6 @@
 {% block content %}
 <h1 class="mb-4">Add New Queen</h1>
 
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    {% for category, message in messages %}
-      <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-        {{ message }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    {% endfor %}
-  {% endif %}
-{% endwith %}
-
-
 {% if hives %}
 <form method="POST" class="row g-3">
   <div class="col-md-6">

--- a/templates/auth_base.html
+++ b/templates/auth_base.html
@@ -16,6 +16,16 @@
         height: 4px;
         transition: width 0.05s linear;
     }
+    .custom-alert {
+        border: 1px solid;
+        border-radius: 0.375rem;
+    }
+    html[data-bs-theme="dark"] .custom-alert {
+        border-color: #fff;
+    }
+    html[data-bs-theme="light"] .custom-alert {
+        border-color: #212529;
+    }
 </style>
 </head>
 <body class="d-flex flex-column min-vh-100">

--- a/templates/auth_base.html
+++ b/templates/auth_base.html
@@ -7,7 +7,16 @@
     <link rel="icon" type="image/png" href="/static/hiverr.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" rel="stylesheet">
-    <link href="https://cdn.materialdesignicons.com/7.4.47/css/materialdesignicons.min.css" rel="stylesheet">
+<link href="https://cdn.materialdesignicons.com/7.4.47/css/materialdesignicons.min.css" rel="stylesheet">
+<style>
+    .alert-progress {
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        height: 4px;
+        transition: width 0.05s linear;
+    }
+</style>
 </head>
 <body class="d-flex flex-column min-vh-100">
     <div class="container py-5">

--- a/templates/auth_base.html
+++ b/templates/auth_base.html
@@ -16,16 +16,6 @@
         height: 4px;
         transition: width 0.05s linear;
     }
-    .custom-alert {
-        border: 1px solid;
-        border-radius: 0.375rem;
-    }
-    html[data-bs-theme="dark"] .custom-alert {
-        border-color: #fff;
-    }
-    html[data-bs-theme="light"] .custom-alert {
-        border-color: #212529;
-    }
 </style>
 </head>
 <body class="d-flex flex-column min-vh-100">

--- a/templates/auth_base.html
+++ b/templates/auth_base.html
@@ -16,19 +16,16 @@
                 <i class="mdi mdi-moon-waning-crescent"></i>
             </button>
         </div>
-        {% with messages = get_flashed_messages(with_categories=true) %}
-          {% if messages %}
-            {% for category, message in messages %}
-              <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-              </div>
-            {% endfor %}
-          {% endif %}
-        {% endwith %}
         {% block content %}{% endblock %}
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='theme.js') }}"></script>
+    <script>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+    showAlert({{ message|tojson }}, "{{ category }}");
+    {% endfor %}
+    {% endwith %}
+    </script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,16 +107,6 @@
             height: 4px;
             transition: width 0.05s linear;
         }
-        .custom-alert {
-            border: 1px solid;
-            border-radius: 0.375rem;
-        }
-        html[data-bs-theme="dark"] .custom-alert {
-            border-color: #fff;
-        }
-        html[data-bs-theme="light"] .custom-alert {
-            border-color: #212529;
-        }
     </style>
 </head>
 <body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -183,17 +183,6 @@
     </div>
 
     <div class="content">
-        {% with messages = get_flashed_messages(with_categories=true) %}
-          {% if messages %}
-            {% for category, message in messages %}
-              <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-              </div>
-            {% endfor %}
-          {% endif %}
-        {% endwith %}
-        
         {% block content %}{% endblock %}
     </div>
 
@@ -216,5 +205,12 @@
         </div>
     </div>
     <script src="{{ url_for('static', filename='theme.js') }}"></script>
+    <script>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+    showAlert({{ message|tojson }}, "{{ category }}");
+    {% endfor %}
+    {% endwith %}
+    </script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -168,6 +168,10 @@
             <div class="d-flex align-items-center justify-content-center gap-2 mt-3">
                 {% if current_user.profile_picture %}
                 <img src="/{{ current_user.profile_picture }}" class="rounded-circle" style="width:32px;height:32px;object-fit:cover;">
+                {% else %}
+                <span class="rounded-circle bg-secondary text-white d-inline-flex align-items-center justify-content-center" style="width:32px;height:32px;">
+                    {{ (current_user.full_name or current_user.username)[0] }}
+                </span>
                 {% endif %}
                 <span class="text-white small">Hi {{ current_user.username }}!</span>
             </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -170,7 +170,7 @@
                 <img src="/{{ current_user.profile_picture }}" class="rounded-circle" style="width:32px;height:32px;object-fit:cover;">
                 {% else %}
                 <span class="rounded-circle bg-secondary text-white d-inline-flex align-items-center justify-content-center" style="width:32px;height:32px;">
-                    {{ (current_user.full_name or current_user.username)[0] }}
+                    {{ (current_user.full_name or current_user.username)[0]|upper }}
                 </span>
                 {% endif %}
                 <span class="text-white small">Hi {{ current_user.username }}!</span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,6 +107,16 @@
             height: 4px;
             transition: width 0.05s linear;
         }
+        .custom-alert {
+            border: 1px solid;
+            border-radius: 0.375rem;
+        }
+        html[data-bs-theme="dark"] .custom-alert {
+            border-color: #fff;
+        }
+        html[data-bs-theme="light"] .custom-alert {
+            border-color: #212529;
+        }
     </style>
 </head>
 <body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -100,6 +100,13 @@
             --bs-table-hover-bg: var(--bs-secondary-bg);
             --bs-table-hover-color: var(--bs-body-color);
         }
+        .alert-progress {
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            height: 4px;
+            transition: width 0.05s linear;
+        }
     </style>
 </head>
 <body>

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -11,13 +11,21 @@
 <form method="POST" id="password-form" class="w-50">
   <div class="mb-3">
     <label for="new_password" class="form-label">New Password</label>
-    <input type="password" class="form-control" id="new_password" name="new_password" required>
+    <div class="input-group">
+      <input type="password" class="form-control" id="new_password" name="new_password" required>
+      <button class="btn btn-outline-secondary toggle-pass" type="button" data-target="new_password"><i class="fa fa-eye"></i></button>
+    </div>
+    <div id="strength-msg" class="form-text">Password must be at least 8 characters long and include one lowercase, one uppercase and one special character.</div>
   </div>
   <div class="mb-3">
     <label for="confirm_password" class="form-label">Confirm Password</label>
-    <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+    <div class="input-group">
+      <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+      <button class="btn btn-outline-secondary toggle-pass" type="button" data-target="confirm_password"><i class="fa fa-eye"></i></button>
+    </div>
+    <div id="match-msg" class="form-text"></div>
   </div>
-  <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmModal">Update Password</button>
+  <button type="button" class="btn btn-primary" id="submit-btn" data-bs-toggle="modal" data-bs-target="#confirmModal">Update Password</button>
   {% if not forced %}
   <a href="{{ url_for('settings') }}" class="btn btn-secondary ms-2">Back</a>
   {% endif %}
@@ -40,4 +48,47 @@
     </div>
   </div>
 </div>
+<script>
+document.querySelectorAll('.toggle-pass').forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    const input=document.getElementById(btn.dataset.target);
+    if(input.type==='password'){
+      input.type='text';
+      btn.innerHTML='<i class="fa fa-eye-slash"></i>';
+    }else{
+      input.type='password';
+      btn.innerHTML='<i class="fa fa-eye"></i>';
+    }
+  });
+});
+const pass=document.getElementById('new_password');
+const confirmP=document.getElementById('confirm_password');
+const strength=document.getElementById('strength-msg');
+const match=document.getElementById('match-msg');
+const submit=document.getElementById('submit-btn');
+const regex=/^(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9]).{8,}$/;
+function validate(){
+  const strong=regex.test(pass.value);
+  if(strong){
+    strength.textContent='This password looks good';
+    strength.className='form-text text-success';
+  }else{
+    strength.textContent='Password must be at least 8 characters long and include one lowercase, one uppercase and one special character.';
+    strength.className='form-text text-danger';
+  }
+  if(pass.value && confirmP.value && pass.value===confirmP.value){
+    match.textContent='Passwords match';
+    match.className='form-text text-success';
+  }else{
+    match.textContent='Passwords do not match';
+    match.className='form-text text-danger';
+  }
+  submit.disabled=!(strong && pass.value===confirmP.value);
+}
+if(pass){
+  pass.addEventListener('input', validate);
+  confirmP.addEventListener('input', validate);
+  validate();
+}
+</script>
 {% endblock %}

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,4 +1,8 @@
+{% if forced %}
+{% extends "auth_base.html" %}
+{% else %}
 {% extends "base.html" %}
+{% endif %}
 
 {% block title %}Change Password - Hiverr{% endblock %}
 
@@ -14,7 +18,9 @@
     <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
   </div>
   <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmModal">Update Password</button>
+  {% if not forced %}
   <a href="{{ url_for('settings') }}" class="btn btn-secondary ms-2">Back</a>
+  {% endif %}
 </form>
 
 <div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">

--- a/templates/edit_apiary.html
+++ b/templates/edit_apiary.html
@@ -4,18 +4,6 @@
 
 {% block content %}
 <h1 class="mb-4">Edit Apiary</h1>
-
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    {% for category, message in messages %}
-      <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-        {{ message }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    {% endfor %}
-  {% endif %}
-{% endwith %}
-
 <form method="POST" class="row g-3">
   <div class="col-md-6">
     <label for="name" class="form-label">Name</label>

--- a/templates/edit_hive.html
+++ b/templates/edit_hive.html
@@ -4,18 +4,6 @@
 
 {% block content %}
 <h1 class="mb-4">Edit Hive</h1>
-
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    {% for category, message in messages %}
-      <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-        {{ message }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    {% endfor %}
-  {% endif %}
-{% endwith %}
-
 <form method="POST" class="row g-3">
   <div class="col-md-6">
     <label for="name" class="form-label">Name</label>

--- a/templates/edit_queen.html
+++ b/templates/edit_queen.html
@@ -4,18 +4,6 @@
 
 {% block content %}
 <h1 class="mb-4">Edit Queen</h1>
-
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    {% for category, message in messages %}
-      <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-        {{ message }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    {% endfor %}
-  {% endif %}
-{% endwith %}
-
 <form method="POST" class="row g-3">
   <div class="col-md-6">
     <label for="name" class="form-label">Name</label>

--- a/templates/login.html
+++ b/templates/login.html
@@ -17,10 +17,12 @@
       </div>
       <button type="submit" class="btn btn-primary w-100">Login</button>
     </form>
+    {% if registration_enabled %}
     <div class="text-center mt-3">
       Need an account?
       <a href="{{ url_for('register') }}" class="btn btn-secondary btn-sm ms-1">Register</a>
     </div>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -96,13 +96,49 @@
         {% endif %}
         <hr class="my-4">
         <h5>Public Registration</h5>
-        <form method="post" action="{{ url_for('toggle_registration') }}" class="form-check form-switch">
-          <input class="form-check-input" type="checkbox" id="regSwitch" name="enable" value="1" {% if registration_enabled %}checked{% endif %} onchange="this.form.submit()">
-          <label class="form-check-label" for="regSwitch">Allow anyone to register</label>
+        <form method="post" action="{{ url_for('toggle_registration') }}" class="form-check form-switch" id="regForm">
+          <input class="form-check-input" type="checkbox" id="regSwitch" name="enable" value="1" {% if registration_enabled %}checked{% endif %}>
+      <label class="form-check-label" for="regSwitch">Allow anyone to register</label>
         </form>
       </div>
     </div>
   </div>
+  {% if current_user.role == 'admin' %}
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="headingUsers">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseUsers" aria-expanded="false" aria-controls="collapseUsers">
+        User Management
+      </button>
+    </h2>
+    <div id="collapseUsers" class="accordion-collapse collapse {% if request.args.get('open') == 'users' %}show{% endif %}" data-bs-parent="#settingsAcc">
+      <div class="accordion-body">
+        <form method="post" action="{{ url_for('create_user') }}">
+          <div class="mb-3">
+            <label for="cu_full_name" class="form-label">Full Name</label>
+            <input type="text" class="form-control" id="cu_full_name" name="full_name" required>
+          </div>
+          <div class="mb-3">
+            <label for="cu_email" class="form-label">Email</label>
+            <input type="email" class="form-control" id="cu_email" name="email">
+          </div>
+          <div class="mb-3">
+            <label for="cu_username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="cu_username" name="username" required>
+          </div>
+          <div class="mb-3">
+            <label for="cu_password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="cu_password" name="password" required>
+          </div>
+          <div class="form-check form-switch mb-3">
+            <input class="form-check-input" type="checkbox" id="force_change" name="force_change" value="1">
+            <label class="form-check-label" for="force_change">Require password change on first login</label>
+          </div>
+          <button type="submit" class="btn btn-primary">Create User</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endif %}
 </div>
 <div class="modal fade" id="setup2FAModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
@@ -151,6 +187,19 @@ function attachSetupHandlers() {
         }
       });
   }, { once: true });
+}
+
+const regSwitch = document.getElementById('regSwitch');
+if(regSwitch){
+  regSwitch.addEventListener('change', () => {
+    fetch(document.getElementById('regForm').action, {
+      method: 'POST',
+      headers:{'Accept':'application/json','Content-Type':'application/x-www-form-urlencoded'},
+      body:'enable='+(regSwitch.checked?1:0)
+    }).then(r=>r.json()).then(data=>{
+      showAlert(data.message, 'success');
+    });
+  });
 }
 </script>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -11,7 +11,7 @@
         Profile
       </button>
     </h2>
-    <div id="collapseProfile" class="accordion-collapse collapse" data-bs-parent="#settingsAcc">
+    <div id="collapseProfile" class="accordion-collapse collapse {% if request.args.get('open') == 'profile' %}show{% endif %}" data-bs-parent="#settingsAcc">
       <div class="accordion-body">
         <form method="POST" enctype="multipart/form-data">
           <input type="hidden" name="section" value="profile">
@@ -42,7 +42,7 @@
         Units &amp; Timezone
       </button>
     </h2>
-    <div id="collapseUnits" class="accordion-collapse collapse" data-bs-parent="#settingsAcc">
+    <div id="collapseUnits" class="accordion-collapse collapse {% if request.args.get('open') == 'units' %}show{% endif %}" data-bs-parent="#settingsAcc">
       <div class="accordion-body">
         <form method="POST">
           <input type="hidden" name="section" value="units">
@@ -79,9 +79,12 @@
         Security
       </button>
     </h2>
-    <div id="collapseSecurity" class="accordion-collapse collapse" data-bs-parent="#settingsAcc">
+    <div id="collapseSecurity" class="accordion-collapse collapse {% if request.args.get('open') == 'security' %}show{% endif %}" data-bs-parent="#settingsAcc">
       <div class="accordion-body">
+        <h5>Change Password</h5>
         <a href="{{ url_for('change_password') }}" class="btn btn-secondary mb-3">Change Password</a>
+        <hr class="my-4">
+        <h5>Two-Factor Authentication</h5>
         {% if user.two_factor_secret %}
           <p>Two-factor authentication is enabled.</p>
           <form method="post" action="{{ url_for('disable_2fa') }}" class="d-inline">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -145,7 +145,7 @@
         <h6 class="mb-2">All Users</h6>
         <table class="table table-sm">
           <thead>
-            <tr><th>User</th><th>Role</th></tr>
+            <tr><th>User</th><th>Role</th><th></th></tr>
           </thead>
           <tbody>
           {% for u in users %}
@@ -159,6 +159,13 @@
                 {{ u.username }}
               </td>
               <td>{{ u.role }}</td>
+              <td>
+                {% if current_user.id != u.id %}
+                <form method="post" action="{{ url_for('delete_user', id=u.id) }}" class="d-inline" onsubmit="return confirm('Delete this user?');">
+                  <button type="submit" class="btn btn-link btn-sm text-danger p-0"><i class="mdi mdi-trash-can-outline"></i></button>
+                </form>
+                {% endif %}
+              </td>
             </tr>
           {% endfor %}
           </tbody>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -91,13 +91,12 @@
           <p>Two-factor authentication is disabled.</p>
           <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary" id="enable-2fa-btn" data-bs-toggle="modal" data-bs-target="#setup2FAModal">Enable 2FA</a>
         {% endif %}
-        {% if not registration_enabled %}
-          <form method="post" action="{{ url_for('enable_registration') }}" class="mt-3">
-            <button type="submit" class="btn btn-warning">Enable Registration</button>
-          </form>
-        {% else %}
-          <p class="mt-3">Registration is enabled.</p>
-        {% endif %}
+        <hr class="my-4">
+        <h5>Public Registration</h5>
+        <form method="post" action="{{ url_for('toggle_registration') }}" class="form-check form-switch">
+          <input class="form-check-input" type="checkbox" id="regSwitch" name="enable" value="1" {% if registration_enabled %}checked{% endif %} onchange="this.form.submit()">
+          <label class="form-check-label" for="regSwitch">Allow anyone to register</label>
+        </form>
       </div>
     </div>
   </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -29,7 +29,7 @@
           </div>
           <div class="mb-3">
             <label class="form-label">Role</label>
-            <input type="text" class="form-control" value="{{ user.role }}" readonly>
+            <p class="form-control-plaintext mb-0">{{ user.role }}</p>
           </div>
           <div class="mb-3">
             <label for="profile_picture" class="form-label">Profile Picture</label>
@@ -142,6 +142,7 @@
           <button type="submit" class="btn btn-primary">Create User</button>
         </form>
         <hr class="my-4">
+        <h6 class="mb-2">All Users</h6>
         <table class="table table-sm">
           <thead>
             <tr><th>User</th><th>Role</th></tr>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -135,6 +135,13 @@
             <label for="cu_password" class="form-label">Password</label>
             <input type="password" class="form-control" id="cu_password" name="password" required>
           </div>
+          <div class="mb-3">
+            <label for="cu_role" class="form-label">Role</label>
+            <select id="cu_role" name="role" class="form-select">
+              <option value="user" selected>User</option>
+              <option value="admin">Admin</option>
+            </select>
+          </div>
           <div class="form-check form-switch mb-3">
             <input class="form-check-input" type="checkbox" id="force_change" name="force_change" value="1">
             <label class="form-check-label" for="force_change">Require password change on first login</label>
@@ -161,9 +168,9 @@
               <td>{{ u.role }}</td>
               <td>
                 {% if current_user.id != u.id %}
-                <form method="post" action="{{ url_for('delete_user', id=u.id) }}" class="d-inline" onsubmit="return confirm('Delete this user?');">
-                  <button type="submit" class="btn btn-link btn-sm text-danger p-0"><i class="mdi mdi-trash-can-outline"></i></button>
-                </form>
+                <button type="button" class="btn btn-link btn-sm text-danger p-0 btn-delete-user" data-bs-toggle="modal" data-bs-target="#deleteUserModal" data-url="{{ url_for('delete_user', id=u.id) }}" data-name="{{ u.username }}">
+                  <i class="mdi mdi-trash-can-outline"></i>
+                </button>
                 {% endif %}
               </td>
             </tr>
@@ -174,6 +181,23 @@
     </div>
   </div>
   {% endif %}
+</div>
+<div class="modal fade" id="deleteUserModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form method="post" class="modal-content" id="deleteUserForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Delete User</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to delete <span id="deleteUserName"></span>?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-danger">Delete</button>
+      </div>
+    </form>
+  </div>
 </div>
 <div class="modal fade" id="setup2FAModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
@@ -236,6 +260,13 @@ if(regSwitch){
     });
   });
 }
+
+document.querySelectorAll('.btn-delete-user').forEach(btn=>{
+  btn.addEventListener('click', () => {
+    document.getElementById('deleteUserForm').action = btn.dataset.url;
+    document.getElementById('deleteUserName').textContent = btn.dataset.name;
+  });
+});
 </script>
 {% endblock %}
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -161,7 +161,7 @@
                 {% if u.profile_picture %}
                 <img src="/{{ u.profile_picture }}" class="rounded-circle me-2" style="width:32px;height:32px;object-fit:cover;">
                 {% else %}
-                <span class="rounded-circle bg-secondary text-white d-inline-flex align-items-center justify-content-center me-2" style="width:32px;height:32px;">{{ (u.full_name or u.username)[0] }}</span>
+                <span class="rounded-circle bg-secondary text-white d-inline-flex align-items-center justify-content-center me-2" style="width:32px;height:32px;">{{ (u.full_name or u.username)[0]|upper }}</span>
                 {% endif %}
                 {{ u.username }}
               </td>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -28,6 +28,10 @@
             <input type="email" class="form-control" id="email" name="email" value="{{ user.email or '' }}">
           </div>
           <div class="mb-3">
+            <label class="form-label">Role</label>
+            <input type="text" class="form-control" value="{{ user.role }}" readonly>
+          </div>
+          <div class="mb-3">
             <label for="profile_picture" class="form-label">Profile Picture</label>
             <input type="file" class="form-control" id="profile_picture" name="profile_picture">
           </div>
@@ -95,11 +99,13 @@
           <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary" id="enable-2fa-btn" data-bs-toggle="modal" data-bs-target="#setup2FAModal">Enable 2FA</a>
         {% endif %}
         <hr class="my-4">
+        {% if current_user.role == 'admin' %}
         <h5>Public Registration</h5>
         <form method="post" action="{{ url_for('toggle_registration') }}" class="form-check form-switch" id="regForm">
           <input class="form-check-input" type="checkbox" id="regSwitch" name="enable" value="1" {% if registration_enabled %}checked{% endif %}>
       <label class="form-check-label" for="regSwitch">Allow anyone to register</label>
         </form>
+        {% endif %}
       </div>
     </div>
   </div>
@@ -135,6 +141,27 @@
           </div>
           <button type="submit" class="btn btn-primary">Create User</button>
         </form>
+        <hr class="my-4">
+        <table class="table table-sm">
+          <thead>
+            <tr><th>User</th><th>Role</th></tr>
+          </thead>
+          <tbody>
+          {% for u in users %}
+            <tr>
+              <td>
+                {% if u.profile_picture %}
+                <img src="/{{ u.profile_picture }}" class="rounded-circle me-2" style="width:32px;height:32px;object-fit:cover;">
+                {% else %}
+                <span class="rounded-circle bg-secondary text-white d-inline-flex align-items-center justify-content-center me-2" style="width:32px;height:32px;">{{ (u.full_name or u.username)[0] }}</span>
+                {% endif %}
+                {{ u.username }}
+              </td>
+              <td>{{ u.role }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -91,6 +91,13 @@
           <p>Two-factor authentication is disabled.</p>
           <a href="{{ url_for('setup_2fa') }}" class="btn btn-primary" id="enable-2fa-btn" data-bs-toggle="modal" data-bs-target="#setup2FAModal">Enable 2FA</a>
         {% endif %}
+        {% if not registration_enabled %}
+          <form method="post" action="{{ url_for('enable_registration') }}" class="mt-3">
+            <button type="submit" class="btn btn-warning">Enable Registration</button>
+          </form>
+        {% else %}
+          <p class="mt-3">Registration is enabled.</p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/templates/setup_admin.html
+++ b/templates/setup_admin.html
@@ -23,11 +23,12 @@
           <input type="password" class="form-control" id="password" name="password" required>
           <button class="btn btn-outline-secondary toggle-pass" type="button" data-target="password"><i class="fa fa-eye"></i></button>
         </div>
+        <div id="strength-msg" class="form-text"></div>
       </div>
       <div class="mb-3">
         <label for="confirm" class="form-label">Confirm Password</label>
         <div class="input-group">
-          <input type="password" class="form-control" id="confirm" required>
+          <input type="password" class="form-control" id="confirm" name="confirm" required>
           <button class="btn btn-outline-secondary toggle-pass" type="button" data-target="confirm"><i class="fa fa-eye"></i></button>
         </div>
         <div id="match-msg" class="form-text"></div>
@@ -84,22 +85,31 @@ document.querySelectorAll('.toggle-pass').forEach(btn=>{
 const pass = document.getElementById('password');
 const confirmP = document.getElementById('confirm');
 const msg = document.getElementById('match-msg');
+const strength = document.getElementById('strength-msg');
 const submitBtn = document.querySelector('form button[type="submit"]');
-function checkMatch(){
+const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9]).{8,}$/;
+function validate(){
+  const strong = regex.test(pass.value);
+  if(strong){
+    strength.textContent = 'Looks good';
+    strength.className = 'form-text text-success';
+  }else{
+    strength.textContent = 'Min 8 chars with upper, lower and special';
+    strength.className = 'form-text text-danger';
+  }
   if(pass.value && confirmP.value && pass.value === confirmP.value){
     msg.textContent = 'Passwords match';
     msg.className = 'form-text text-success';
-    submitBtn.disabled = false;
   }else{
     msg.textContent = 'Passwords do not match';
     msg.className = 'form-text text-danger';
-    submitBtn.disabled = true;
   }
+  submitBtn.disabled = !(strong && pass.value === confirmP.value);
 }
 if(pass&&confirmP){
-  pass.addEventListener('input', checkMatch);
-  confirmP.addEventListener('input', checkMatch);
-  checkMatch();
+  pass.addEventListener('input', validate);
+  confirmP.addEventListener('input', validate);
+  validate();
 }
 
 const verifyBtn = document.getElementById('verify-2fa');

--- a/templates/setup_admin.html
+++ b/templates/setup_admin.html
@@ -37,7 +37,7 @@
         <label for="profile_picture" class="form-label">Profile Picture (optional)</label>
         <input type="file" class="form-control" id="profile_picture" name="profile_picture">
       </div>
-      <div class="form-check mb-3">
+      <div class="form-check form-switch mb-3">
         <input class="form-check-input" type="checkbox" value="1" id="enable2fa" name="enable2fa">
         <label class="form-check-label" for="enable2fa">Enable Two-Factor Authentication</label>
       </div>

--- a/templates/setup_admin.html
+++ b/templates/setup_admin.html
@@ -23,7 +23,7 @@
           <input type="password" class="form-control" id="password" name="password" required>
           <button class="btn btn-outline-secondary toggle-pass" type="button" data-target="password"><i class="fa fa-eye"></i></button>
         </div>
-        <div id="strength-msg" class="form-text"></div>
+        <div id="strength-msg" class="form-text">Password must be at least 8 characters long and include one lowercase, one uppercase and one special character.</div>
       </div>
       <div class="mb-3">
         <label for="confirm" class="form-label">Confirm Password</label>
@@ -91,10 +91,10 @@ const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9]).{8,}$/;
 function validate(){
   const strong = regex.test(pass.value);
   if(strong){
-    strength.textContent = 'Looks good';
+    strength.textContent = 'This password looks good';
     strength.className = 'form-text text-success';
   }else{
-    strength.textContent = 'Min 8 chars with upper, lower and special';
+    strength.textContent = 'Password must be at least 8 characters long and include one lowercase, one uppercase and one special character.';
     strength.className = 'form-text text-danger';
   }
   if(pass.value && confirmP.value && pass.value === confirmP.value){

--- a/templates/setup_admin.html
+++ b/templates/setup_admin.html
@@ -1,0 +1,69 @@
+{% extends "auth_base.html" %}
+{% block title %}Administrator Setup - Hiverr{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 480px;">
+    <h1 class="card-title mb-3 text-center">Create Administrator Account</h1>
+    <form method="POST" enctype="multipart/form-data">
+      <div class="mb-3">
+        <label for="full_name" class="form-label">Full Name</label>
+        <input type="text" class="form-control" id="full_name" name="full_name" required>
+      </div>
+      <div class="mb-3">
+        <label for="email" class="form-label">Email (optional)</label>
+        <input type="email" class="form-control" id="email" name="email">
+      </div>
+      <div class="mb-3">
+        <label for="username" class="form-label">Username</label>
+        <input type="text" class="form-control" id="username" name="username" required>
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <div class="mb-3">
+        <label for="profile_picture" class="form-label">Profile Picture (optional)</label>
+        <input type="file" class="form-control" id="profile_picture" name="profile_picture">
+      </div>
+      <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" value="1" id="enable2fa" name="enable2fa">
+        <label class="form-check-label" for="enable2fa">Enable Two-Factor Authentication</label>
+      </div>
+      <div id="twofa-section" class="border rounded p-3 mb-3 d-none">
+        <p class="text-center">Scan the QR code or enter the secret below.</p>
+        {% if qr_data %}
+        <img src="{{ qr_data }}" alt="QR" class="d-block mx-auto mb-2" />
+        {% endif %}
+        <pre class="text-center">{{ secret }}</pre>
+        <div class="mb-3">
+          <label for="token" class="form-label">Authentication Code</label>
+          <input type="text" class="form-control" id="token" name="token">
+        </div>
+      </div>
+      <h5 class="mt-4">Optional: Initial Setup</h5>
+      <div class="mb-3">
+        <label for="apiary_name" class="form-label">Apiary Name</label>
+        <input type="text" class="form-control" id="apiary_name" name="apiary_name">
+      </div>
+      <div class="mb-3">
+        <label for="hive_name" class="form-label">Hive Name</label>
+        <input type="text" class="form-control" id="hive_name" name="hive_name">
+      </div>
+      <div class="mb-3">
+        <label for="queen_name" class="form-label">Queen Name</label>
+        <input type="text" class="form-control" id="queen_name" name="queen_name">
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Create Administrator</button>
+    </form>
+  </div>
+</div>
+<script>
+const cb = document.getElementById('enable2fa');
+const section = document.getElementById('twofa-section');
+if(cb){
+  cb.addEventListener('change', ()=>{
+    section.classList.toggle('d-none', !cb.checked);
+  });
+}
+</script>
+{% endblock %}

--- a/templates/setup_admin.html
+++ b/templates/setup_admin.html
@@ -19,7 +19,18 @@
       </div>
       <div class="mb-3">
         <label for="password" class="form-label">Password</label>
-        <input type="password" class="form-control" id="password" name="password" required>
+        <div class="input-group">
+          <input type="password" class="form-control" id="password" name="password" required>
+          <button class="btn btn-outline-secondary toggle-pass" type="button" data-target="password"><i class="fa fa-eye"></i></button>
+        </div>
+      </div>
+      <div class="mb-3">
+        <label for="confirm" class="form-label">Confirm Password</label>
+        <div class="input-group">
+          <input type="password" class="form-control" id="confirm" required>
+          <button class="btn btn-outline-secondary toggle-pass" type="button" data-target="confirm"><i class="fa fa-eye"></i></button>
+        </div>
+        <div id="match-msg" class="form-text"></div>
       </div>
       <div class="mb-3">
         <label for="profile_picture" class="form-label">Profile Picture (optional)</label>
@@ -37,21 +48,12 @@
         <pre class="text-center">{{ secret }}</pre>
         <div class="mb-3">
           <label for="token" class="form-label">Authentication Code</label>
-          <input type="text" class="form-control" id="token" name="token">
+          <div class="input-group">
+            <input type="text" class="form-control" id="token" name="token">
+            <button type="button" class="btn btn-outline-primary" id="verify-2fa">Verify</button>
+          </div>
+          <div id="verify-msg" class="form-text"></div>
         </div>
-      </div>
-      <h5 class="mt-4">Optional: Initial Setup</h5>
-      <div class="mb-3">
-        <label for="apiary_name" class="form-label">Apiary Name</label>
-        <input type="text" class="form-control" id="apiary_name" name="apiary_name">
-      </div>
-      <div class="mb-3">
-        <label for="hive_name" class="form-label">Hive Name</label>
-        <input type="text" class="form-control" id="hive_name" name="hive_name">
-      </div>
-      <div class="mb-3">
-        <label for="queen_name" class="form-label">Queen Name</label>
-        <input type="text" class="form-control" id="queen_name" name="queen_name">
       </div>
       <button type="submit" class="btn btn-primary w-100">Create Administrator</button>
     </form>
@@ -63,6 +65,61 @@ const section = document.getElementById('twofa-section');
 if(cb){
   cb.addEventListener('change', ()=>{
     section.classList.toggle('d-none', !cb.checked);
+  });
+}
+
+document.querySelectorAll('.toggle-pass').forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    const input = document.getElementById(btn.dataset.target);
+    if(input.type === 'password'){
+      input.type = 'text';
+      btn.innerHTML = '<i class="fa fa-eye-slash"></i>';
+    }else{
+      input.type = 'password';
+      btn.innerHTML = '<i class="fa fa-eye"></i>';
+    }
+  });
+});
+
+const pass = document.getElementById('password');
+const confirmP = document.getElementById('confirm');
+const msg = document.getElementById('match-msg');
+const submitBtn = document.querySelector('form button[type="submit"]');
+function checkMatch(){
+  if(pass.value && confirmP.value && pass.value === confirmP.value){
+    msg.textContent = 'Passwords match';
+    msg.className = 'form-text text-success';
+    submitBtn.disabled = false;
+  }else{
+    msg.textContent = 'Passwords do not match';
+    msg.className = 'form-text text-danger';
+    submitBtn.disabled = true;
+  }
+}
+if(pass&&confirmP){
+  pass.addEventListener('input', checkMatch);
+  confirmP.addEventListener('input', checkMatch);
+  checkMatch();
+}
+
+const verifyBtn = document.getElementById('verify-2fa');
+if(verifyBtn){
+  verifyBtn.addEventListener('click', ()=>{
+    const token = document.getElementById('token').value;
+    fetch('{{ url_for('setup_admin_verify_2fa') }}', {
+      method:'POST',
+      headers:{'Content-Type':'application/x-www-form-urlencoded'},
+      body:'token='+encodeURIComponent(token)
+    }).then(r=>r.json()).then(data=>{
+      const vm = document.getElementById('verify-msg');
+      if(data.ok){
+        vm.textContent = 'Two-factor saved';
+        vm.className = 'form-text text-success';
+      }else{
+        vm.textContent = 'Invalid code';
+        vm.className = 'form-text text-danger';
+      }
+    });
   });
 }
 </script>

--- a/templates/setup_apiary.html
+++ b/templates/setup_apiary.html
@@ -1,0 +1,27 @@
+{% extends "auth_base.html" %}
+{% block title %}Initial Setup - Hiverr{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 480px;">
+    <h1 class="card-title mb-3 text-center">Initial Apiary Setup</h1>
+    <form method="POST">
+      <div class="mb-3">
+        <label for="apiary_name" class="form-label">Apiary Name</label>
+        <input type="text" class="form-control" id="apiary_name" name="apiary_name">
+      </div>
+      <div class="mb-3">
+        <label for="hive_name" class="form-label">Hive Name</label>
+        <input type="text" class="form-control" id="hive_name" name="hive_name">
+      </div>
+      <div class="mb-3">
+        <label for="queen_name" class="form-label">Queen Name</label>
+        <input type="text" class="form-control" id="queen_name" name="queen_name">
+      </div>
+      <div class="d-flex justify-content-between">
+        <a href="{{ url_for('index') }}" class="btn btn-secondary">Skip</a>
+        <button type="submit" class="btn btn-primary">Finish Setup</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `role` to users
- block registration after admin creation
- redirect to `/setup-admin` when no users exist
- create `/setup-admin` route for first-run admin setup
- provide template for admin setup without sidebar

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491e2de740832e9afb45273419adbf